### PR TITLE
Fix: Move @gh-netic-robot to default codeowners line

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,2 @@
-* @neticdk/cloud-native
-* @neticdk/platform-development
-
-* @gh-netic-robot
+* @neticdk/cloud-native @gh-netic-robot
+* @neticdk/platform-development @gh-netic-robot


### PR DESCRIPTION
This PR removes the separate `@gh-netic-robot` line and appends it to the existing default `*` line to consolidate ownership.